### PR TITLE
Fix missing import of functools.partial

### DIFF
--- a/veomni/models/module_utils.py
+++ b/veomni/models/module_utils.py
@@ -19,6 +19,7 @@ from collections import OrderedDict
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, List, Literal, Optional, Sequence, Tuple, Union
+from functools import partial
 
 import torch
 # from hdfs_io import hput


### PR DESCRIPTION
Add missing import of functools.partial to prevent "NameError: name 'partial' is not defined" when enabling enable_gradient_checkpointing in training config.

**How reproduce the bug**

Environment: CUDA==12.9.86  torch==2.8.0  Python==3.11.14

Config with gradient checkpointing enabled:

```yaml
model:
  model_path: Qwen/Qwen3-8B
  attn_implementation: flash_attention_2

data:
  train_path: ./data/data
  train_size: 50_000_000_000
  dataloader_type: native
  data_type: plaintext
  max_seq_len: 2096
  text_keys: text
  drop_last: true
  datasets_type: mapping
  prefetch_factor: 2
  num_workers: 2

train:
  output_dir: "./output/oDLLM_qwen3_8B"
  repr_align_wt: 10  # Weight for representation alignment loss (0 = disabled)
  freeze_layers: ""  # Example: "attn" to freeze attention, "mlp" to freeze FFN, "attn,mlp" for both
  data_parallel_mode: fsdp1
  ulysses_parallel_size: 1
  global_batch_size: 64
  micro_batch_size: 1
  rmpad: false
  rmpad_with_pos_ids: true
  enable_masking: true
  bsz_warmup_ratio: 0.00
  dyn_bsz_margin: 0
  dyn_bsz_buffer_size: 100
  optimizer: adamw
  lr: 3e-4
  lr_decay_style: cosine
  lr_warmup_ratio: 0.001
  lr_decay_ratio: 1.0  # Use full training for decay
  lr_min: 3e-6        # Minimum LR
  weight_decay: 0.01
  max_grad_norm: 1.0
  enable_mixed_precision: true
  enable_gradient_checkpointing: true
  enable_full_shard: true
  enable_fsdp_offload: false
  enable_activation_offload: false
  init_device: meta
  enable_full_determinism: false
  empty_cache_steps: 1000
  ckpt_manager: dcp
  load_checkpoint_path: ""
  save_steps: 10_000
  save_hf_weights: true
  use_wandb: false
  save_time_interval_minutes: 170 # less than 3 hours
  auto_resume: true
  eval_every: 0
```

Run the script:

```bash
export TOKENIZERS_PARALLELISM=false

NNODES=${NNODES:=1}
NPROC_PER_NODE=$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)
NODE_RANK=${NODE_RANK:=0}
MASTER_ADDR=${MASTER_ADDR:=0.0.0.0}
MASTER_PORT=${MASTER_PORT:=12345}

torchrun --nnodes=$NNODES --nproc-per-node $NPROC_PER_NODE --node-rank $NODE_RANK   --master-addr=$MASTER_ADDR --master-port=$MASTER_PORT  tasks/train_torch.py \
configs/pretrain/qwen3_8B.yaml
```

Error (last lines):

```plaintext
[rank0]:   File "/home/jovyan/inkoziev/github/Open-dLLM.PR/Open-dLLM/veomni/models/module_utils.py", line 426, in __call__
[rank0]:     return self._gradient_checkpointing_func(partial(super().__call__, **kwargs), *args)
[rank0]:                                              ^^^^^^^
[rank0]: NameError: name 'partial' is not defined
```

**Hot to fix**

Add `from functools import partial` in `veomni/models/module_utils.py`

resolve #33 